### PR TITLE
Updated README to include proper default output folder of lint-results.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Android resources have dependencies to each other. This means that after running
 
 e.g.
 
-    ./gradlew clean build :lint && android-resource-remover --xml build/lint-results.xml
+    ./gradlew clean build :lint && android-resource-remover --xml build/outputs/lint-results.xml
 
 
 ### Options


### PR DESCRIPTION
The output folder has changed since quite a while. Thanks for the tool guys, it's very helpful :)