### PR TITLE
Make script executable and add shebang

### DIFF
--- a/android_clean_app.py
+++ b/android_clean_app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
     clean_app
     ~~~~~~~~~~

--- a/test/test_clean_app.py
+++ b/test/test_clean_app.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import os
 import unittest
 import android_clean_app as clean_app


### PR DESCRIPTION
Sets the file mode of the Python scripts to **755** (`chmod +x`) and adds a [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29) for easier execution on Unix based operating systems.