### PR TITLE
Fix build command for gradle 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Android resources have dependencies to each other. This means that after running
 
 e.g.
 
-    ./gradlew clean build :lint && android-resource-remover --xml build/outputs/lint-results.xml
+    ./gradlew clean build && android-resource-remover --xml build/outputs/lint-results.xml
 
 
 ### Options

--- a/android_clean_app.py
+++ b/android_clean_app.py
@@ -119,8 +119,9 @@ def remove_resource_value(issue, filepath):
                                  remove_pis=False, strip_cdata=False, resolve_entities=False)
         tree = etree.parse(filepath, parser)
         root = tree.getroot()
-        for unused_value in root.findall('.//{0}[@name="{1}"]'.format(element[0], element[1])):
-            root.remove(unused_value)
+        for unused_value in root.findall(element[0]):
+            if unused_value.get('name') == element[1]:
+                root.remove(unused_value)
         with open(filepath, 'wb') as resource:
             tree.write(resource, encoding='utf-8', xml_declaration=True)
 


### PR DESCRIPTION
Build failed with gradle 2.2.1:

./gradlew clean build :lint

FAILURE: Build failed with an exception.

What went wrong: Task 'lint' not found in root project 'xxx'. Some candidates are: 'init'.
BUILD FAILED