### PR TITLE
Features/remove untranslatable strings

### DIFF
--- a/android_clean_app.py
+++ b/android_clean_app.py
@@ -45,6 +45,7 @@ class Issue:
                   "can't remove it. The pattern might have changed, please check and report this in github issues." % (
                       self.pattern, message))
 
+
 class UnusedResourceIssue(Issue):
     pattern = re.compile('The resource `?([^`]+)`? appears to be unused')
 
@@ -109,6 +110,7 @@ def get_manifest_string_refs(manifest_path):
         data = f.read()
         refs = set(re.findall(pattern, data))
         return [x.replace('/', '.') for x in refs]
+
 
 def _get_issues_from_location(issue_class, locations, message):
     issues = []

--- a/android_clean_app.py
+++ b/android_clean_app.py
@@ -24,7 +24,6 @@ class Issue:
     """
     Stores a single issue reported by Android Lint
     """
-    pattern = re.compile('The resource `?([^`]+)`? appears to be unused')
 
     def __init__(self, filepath, remove_file):
         self.filepath = filepath
@@ -38,15 +37,27 @@ class Issue:
         return '{0} {1}'.format(self.filepath, self.elements)
 
     def add_element(self, message):
-        res_all = re.findall(Issue.pattern, message)
+        res_all = re.findall(self.pattern, message)
         if res_all:
-            res = res_all[0]
-            bits = res.split('.')[-2:]
-            self.elements.append((bits[0], bits[1]))
+            self._process_match(res_all)
         else:
             print("The pattern '%s' seems to find nothing in the error message '%s'. We can't find the resource and "
                   "can't remove it. The pattern might have changed, please check and report this in github issues." % (
-                      Issue.pattern, message))
+                      self.pattern, message))
+
+class UnusedResourceIssue(Issue):
+    pattern = re.compile('The resource `?([^`]+)`? appears to be unused')
+
+    def _process_match(self, match_result):
+        bits = match_result[0].split('.')[-2:]
+        self.elements.append((bits[0], bits[1]))
+
+
+class ExtraTranslationIssue(Issue):
+    pattern = re.compile('The resource string \"`([^`]+)`\" has been marked as `translatable=\"false')
+
+    def _process_match(self, match_result):
+        self.elements.append(('string', match_result[0]))
 
 
 def parse_args():
@@ -99,6 +110,19 @@ def get_manifest_string_refs(manifest_path):
         refs = set(re.findall(pattern, data))
         return [x.replace('/', '.') for x in refs]
 
+def _get_issues_from_location(issue_class, locations, message):
+    issues = []
+    for location in locations:
+        filepath = location.get('file')
+        # if the location contains line and/or column attribute not the entire resource is unused.
+        # that's a guess ;)
+        # TODO stop guessing
+        remove_entire_file = (location.get('line') or location.get('column')) is None
+        issue = issue_class(filepath, remove_entire_file)
+        issue.add_element(message)
+        issues.append(issue)
+    return issues
+
 
 def parse_lint_result(lint_result_path, manifest_path):
     """
@@ -110,18 +134,21 @@ def parse_lint_result(lint_result_path, manifest_path):
     issues = []
 
     for issue_xml in root.findall('.//issue[@id="UnusedResources"]'):
+        message = issue_xml.get('message')
         unused_string = re.match(unused_string_pattern, issue_xml.get('message'))
         has_string_in_manifest = unused_string and unused_string.group(1) in mainfest_string_refs
         if not has_string_in_manifest:
-            for location in issue_xml.findall('location'):
-                filepath = location.get('file')
-                # if the location contains line and/or column attribute not the entire resource is unused.
-                # that's a guess ;)
-                # TODO stop guessing
-                remove_entire_file = (location.get('line') or location.get('column')) is None
-                issue = Issue(filepath, remove_entire_file)
-                issue.add_element(issue_xml.get('message'))
-                issues.append(issue)
+            issues.extend(_get_issues_from_location(UnusedResourceIssue,
+                                                    issue_xml.findall('location'),
+                                                    message))
+
+    for issue_xml in root.findall('.//issue[@id="ExtraTranslation"]'):
+        message = issue_xml.get('message')
+        if re.findall(ExtraTranslationIssue.pattern, message):
+            issues.extend(_get_issues_from_location(ExtraTranslationIssue,
+                                                    issue_xml.findall('location'),
+                                                    message))
+
     return issues
 
 

--- a/test/android_app/AndroidManifest.xml
+++ b/test/android_app/AndroidManifest.xml
@@ -12,5 +12,8 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity android:name="SampleActivity"
+                  android:label="@string/untranslatable">
+        </activity>
     </application>
 </manifest>

--- a/test/android_app/lint-result.xml
+++ b/test/android_app/lint-result.xml
@@ -297,4 +297,22 @@ Low density is not really used much anymore, so this check ignores the ldpi dens
             column="13"/>
     </issue>
 
+    <issue
+        id="ExtraTranslation"
+        severity="Fatal"
+        message="The resource string &quot;`untranslatable`&quot; has been marked as `translatable=&quot;false&quot;`"
+        category="Correctness:Messages"
+        priority="6"
+        summary="Extra translation"
+        explanation="If a string appears in a specific language translation file, but there is no corresponding string in the default locale, then this string is probably unused. (It&apos;s technically possible that your application is only intended to run in a specific locale, but it&apos;s still a good idea to provide a fallback.).
+
+Note that these strings can lead to crashes if the string is looked up on any locale not providing a translation, so it&apos;s important to clean them up."
+        errorLine1="    &lt;string name=&quot;untranslatable&quot;>untraslateable caption&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="res/values-fr/strings.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
 </issues>

--- a/test/android_app/res/values-fr/strings.xml
+++ b/test/android_app/res/values-fr/strings.xml
@@ -2,5 +2,6 @@
 <resources>
     <string name="app_name">android_app</string>
     <string name="missing">missing</string>
+    <string name="untranslatable">untraslatable caption</string>
     <string name="extra_translation">missing</string>
 </resources>

--- a/test/android_app/res/values/strings.xml
+++ b/test/android_app/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">android_app</string>
+    <string name="untranslatable" translatable="false">untraslatable caption</string>
     <string name="missing">missing</string>
 </resources>


### PR DESCRIPTION
Solves #35
Removes translations strings, which are marked as `untranslatable=false` in default locale